### PR TITLE
Revamped Genesys Messenger Demo page 

### DIFF
--- a/examples/genesys-messenger-integration/iconStyling.js
+++ b/examples/genesys-messenger-integration/iconStyling.js
@@ -1,0 +1,43 @@
+// Wait for the ve-launcher element to be created
+function waitForElement(selector, callback) {
+    const element = document.getElementById(selector);
+    if (element) {
+        callback(element);
+    } else {
+        setTimeout(() => waitForElement(selector, callback), 100);
+    }
+}
+
+// Wait for element by class name
+function waitForElementByClass(className, callback) {
+    const element = document.querySelector('.' + className);
+    if (element) {
+        callback(element);
+    } else {
+        setTimeout(() => waitForElementByClass(className, callback), 100);
+    }
+}
+
+// Wait for ve-launcher to exist, then move it to left-circle
+waitForElement('ve-launcher', function(launcher) {
+    const leftCircle = document.querySelector('.left-circle');
+    if (leftCircle) {
+        // Move the launcher inside the left-circle
+        leftCircle.appendChild(launcher);
+        console.log('VE Launcher moved to left-circle!');
+    } else {
+        console.log('Left circle not found');
+    }
+});
+
+// Wait for genesys-mxg-frame to exist, then move it to right-circle
+waitForElementByClass('genesys-mxg-frame', function(genesysFrame) {
+    const rightCircle = document.querySelector('.right-circle');
+    if (rightCircle) {
+        // Move the genesys frame inside the right-circle
+        rightCircle.appendChild(genesysFrame);
+        console.log('Genesys frame moved to right-circle!');
+    } else {
+        console.log('Right circle not found');
+    }
+});

--- a/examples/genesys-messenger-integration/iconStyling.js
+++ b/examples/genesys-messenger-integration/iconStyling.js
@@ -25,10 +25,6 @@ waitForElement('ve-launcher', function(launcher) {
         // Move the launcher inside the left-circle
         leftCircle.appendChild(launcher);
         console.log('VE Launcher moved to left-circle!');
-    } else {
-        // VE Launcher moved to left-circle
-    } else {
-        // Left circle not found
     }
 });
 
@@ -39,9 +35,5 @@ waitForElementByClass('genesys-mxg-frame', function(genesysFrame) {
         // Move the genesys frame inside the right-circle
         rightCircle.appendChild(genesysFrame);
         console.log('Genesys frame moved to right-circle!');
-    } else {
-        // Genesys frame moved to right-circle
-    } else {
-        // Right circle not found
     }
 });

--- a/examples/genesys-messenger-integration/iconStyling.js
+++ b/examples/genesys-messenger-integration/iconStyling.js
@@ -26,7 +26,9 @@ waitForElement('ve-launcher', function(launcher) {
         leftCircle.appendChild(launcher);
         console.log('VE Launcher moved to left-circle!');
     } else {
-        console.log('Left circle not found');
+        // VE Launcher moved to left-circle
+    } else {
+        // Left circle not found
     }
 });
 

--- a/examples/genesys-messenger-integration/iconStyling.js
+++ b/examples/genesys-messenger-integration/iconStyling.js
@@ -24,7 +24,6 @@ waitForElement('ve-launcher', function(launcher) {
     if (leftCircle) {
         // Move the launcher inside the left-circle
         leftCircle.appendChild(launcher);
-        console.log('VE Launcher moved to left-circle!');
     }
 });
 
@@ -34,6 +33,5 @@ waitForElementByClass('genesys-mxg-frame', function(genesysFrame) {
     if (rightCircle) {
         // Move the genesys frame inside the right-circle
         rightCircle.appendChild(genesysFrame);
-        console.log('Genesys frame moved to right-circle!');
     }
 });

--- a/examples/genesys-messenger-integration/iconStyling.js
+++ b/examples/genesys-messenger-integration/iconStyling.js
@@ -38,6 +38,8 @@ waitForElementByClass('genesys-mxg-frame', function(genesysFrame) {
         rightCircle.appendChild(genesysFrame);
         console.log('Genesys frame moved to right-circle!');
     } else {
-        console.log('Right circle not found');
+        // Genesys frame moved to right-circle
+    } else {
+        // Right circle not found
     }
 });

--- a/examples/genesys-messenger-integration/index.html
+++ b/examples/genesys-messenger-integration/index.html
@@ -41,7 +41,11 @@
     <div class="main-container">
         <h1 class="main-title">VideoEngager</h1>
         <h2>Genesys Messenger Integration</h2>
-        <h3>Check the bottom corners!</h3>  
+        <ul class="widget-functionalities">
+            Use Widget Buttons to see demos in action
+            <li><i>Click Video button for Click-to-Video with an Agent</i></li>
+            <li><i>Click Message button to initiate chat with And Agent that can be escalated to Video</i></li>
+        </ul>  
     </div>
         <div class="left-circle"></div>
         <div class="right-circle"></div>

--- a/examples/genesys-messenger-integration/index.html
+++ b/examples/genesys-messenger-integration/index.html
@@ -44,7 +44,11 @@
         <ul class="widget-functionalities">
             Use Widget Buttons to see demos in action
             <li><i>Click Video button for Click-to-Video with an Agent</i></li>
+            <li>Use Widget Buttons to see demos in action</li>
+            <li><i>Click Video button for Click-to-Video with an Agent</i></li>
             <li><i>Click Message button to initiate chat with And Agent that can be escalated to Video</i></li>
+            <li><i>Click Video button for Click-to-Video with an Agent</i></li>
+            <li><i>Click Message button to initiate chat with an Agent that can be escalated to Video</i></li>
         </ul>  
     </div>
         <div class="left-circle"></div>

--- a/examples/genesys-messenger-integration/index.html
+++ b/examples/genesys-messenger-integration/index.html
@@ -6,8 +6,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>VideoEngager Genesys Messenger Integration</title>
+    <link rel='stylesheet' href="./styles.css">
     <script type="text/javascript" src="videoengager-genesys-messenger.js"></script>
     <script type="text/javascript" src="demo.js"></script>
+    <script type="text/javascript" src="iconStyling.js"></script>
 
     <style>
         .github-btn-container {
@@ -36,8 +38,13 @@
             View Source on GitHub
         </a>
     </div>
-
-
+    <div class="main-container">
+        <h1 class="main-title">VideoEngager</h1>
+        <h2>Genesys Messenger Integration</h2>
+        <h3>Check the bottom corners!</h3>  
+    </div>
+        <div class="left-circle"></div>
+        <div class="right-circle"></div>
 </body>
 
 </html>

--- a/examples/genesys-messenger-integration/index.html
+++ b/examples/genesys-messenger-integration/index.html
@@ -30,7 +30,6 @@
 
         </style>
 </head>
-
 <body class="p-4">
     <div class="github-btn-container">
         <a style="color: white;text-decoration: none;" href="https://github.com/VideoEngager/videoengager.github.io/tree/master/examples/genesys-messenger-integration" target="_blank" class="github-source-btn btn btn-dark">
@@ -42,11 +41,7 @@
         <h1 class="main-title">VideoEngager</h1>
         <h2>Genesys Messenger Integration</h2>
         <ul class="widget-functionalities">
-            Use Widget Buttons to see demos in action
-            <li><i>Click Video button for Click-to-Video with an Agent</i></li>
-            <li>Use Widget Buttons to see demos in action</li>
-            <li><i>Click Video button for Click-to-Video with an Agent</i></li>
-            <li><i>Click Message button to initiate chat with And Agent that can be escalated to Video</i></li>
+            <div>Use Widget Buttons to see demos in action</div>
             <li><i>Click Video button for Click-to-Video with an Agent</i></li>
             <li><i>Click Message button to initiate chat with an Agent that can be escalated to Video</i></li>
         </ul>  
@@ -54,5 +49,4 @@
         <div class="left-circle"></div>
         <div class="right-circle"></div>
 </body>
-
 </html>

--- a/examples/genesys-messenger-integration/styles.css
+++ b/examples/genesys-messenger-integration/styles.css
@@ -2,30 +2,35 @@
   font-family: Avenir, Helvetica, Arial, sans-serif;
   font-weight: 400;
   line-height: 1.5;
-  border: 2px solid black;
-  border-radius: 16px;
-  background-color: rgb(25, 108, 177);
-  text-align: center;
-  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(25, 108, 177, 0.96), rgba(17, 76, 129, 0.96));
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  padding: 48px 40px;
+  width: min(820px, calc(100% - 48px));
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  padding: 40px 30px;
+  text-align: center;
 }
 
 .main-title {
   color: white;
-  font-size: 2.5rem;
-  font-weight: 300;
+  font-size: clamp(2rem, 2.5vw + 1rem, 3rem);
+  font-weight: 600;
+  letter-spacing: 0.3px;
   margin: 0 0 5px 0;
 }
 
 h2 {
     font-weight: 500;
-    font-size: 1.8rem;
+    font-size: clamp(1.25rem, 1.2vw + 1rem, 1.75rem);
     margin: 0 0 15px 0;
-    color: #f0f8ff;
+    color: #e6f3ff;
+    opacity: 0.95;
 }
 
 h3 {
@@ -36,6 +41,7 @@ h3 {
 
 p {
     color: rgba(255, 255, 255, 0.829);
+    line-height: 1.7;
 }
 
 @keyframes pulse {
@@ -90,4 +96,57 @@ p {
   position: relative !important;
   bottom: -6% !important;
   right: auto !important;
+}
+
+.widget-functionalities {
+  text-align: start;
+  margin: 16px 0 0 0;
+  padding: 0;
+  list-style: none;
+  color: rgba(255, 255, 255, 0.92);
+}
+.widget-functionalities > li {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin: 10px 0;
+}
+.widget-functionalities > li::before {
+  content: "";
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin-top: 8px;
+  border-radius: 2px;
+  background: #7dd3fc; /* sky blue accent bullet */
+  box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.25);
+  flex: 0 0 auto;
+}
+
+/* Subtle divider under headings */
+.main-container .main-title + h2 {
+  position: relative;
+  padding-bottom: 8px;
+}
+.main-container .main-title + h2::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: -2px;
+  transform: translateX(-50%);
+  width: 64px;
+  height: 3px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, transparent, #7dd3fc, transparent);
+  opacity: 0.9;
+}
+
+/* Responsive tweaks */
+@media (max-width: 640px) {
+  .main-container {
+    padding: 28px 22px;
+  }
+  .widget-functionalities > li {
+    margin: 8px 0;
+  }
 }

--- a/examples/genesys-messenger-integration/styles.css
+++ b/examples/genesys-messenger-integration/styles.css
@@ -1,0 +1,93 @@
+.main-container {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  font-weight: 400;
+  line-height: 1.5;
+  border: 2px solid black;
+  border-radius: 16px;
+  background-color: rgb(25, 108, 177);
+  text-align: center;
+  color: white;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 40px 30px;
+}
+
+.main-title {
+  color: white;
+  font-size: 2.5rem;
+  font-weight: 300;
+  margin: 0 0 5px 0;
+}
+
+h2 {
+    font-weight: 500;
+    font-size: 1.8rem;
+    margin: 0 0 15px 0;
+    color: #f0f8ff;
+}
+
+h3 {
+    font-weight: 400;
+    margin: 0 0 15px 0;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+p {
+    color: rgba(255, 255, 255, 0.829);
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.left-circle {
+  position: fixed;
+  bottom: 0.8%;
+  left: 1%;
+  width: 80px;
+  height: 80px;
+  background-color: transparent;
+  border: 3px solid red;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: pulse 2s infinite ease-in-out;
+}
+
+.right-circle {
+  position: fixed;
+  bottom: 0.8%;
+  right: 1%;
+  width: 80px;
+  height: 80px;
+  background-color: transparent;
+  border: 3px solid red;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: pulse 2s infinite ease-in-out;
+}
+
+#ve-launcher {
+  position: relative !important;
+  bottom: auto !important;
+  left: auto !important;
+}
+
+.genesys-mxg-frame {
+  position: relative !important;
+  bottom: -6% !important;
+  right: auto !important;
+}


### PR DESCRIPTION
## Overview 
This is a task me and George discussed - the current Genesys Messenger Integration page is a blank white page, with the difficult to notice VideoEngager widgets in the bottom corner. 
The current page looks like this: https://videoengager.github.io/examples/genesys-messenger-integration/index.html

Snapshot of new page: 
<img width="1920" height="887" alt="Screenshot 2025-08-18 at 9 11 02 PM" src="https://github.com/user-attachments/assets/3ae50e49-e219-4f94-8ce2-2fa14a78f860" />


## Changes
I made 2 major changes to the page: 
    1. VideoEngager Banner - This stands as a general explanation of the page - explains the purpose of the demo and which              
        widget does what functionality. 
    2. Red highlight around widgets, with a pulsing (widget shrinking and growing) animation - This really helps with noticing     
        the widgets, especially because they usually take a few seconds to load.

George wanted arrows pointing to the corners instead of the red circle - This is something I'm still working on implementing, but for the time being I wanted to submit what was already done. 

Open to any suggestions on how I can improve the page further; just send me an email at stefankvitanov@gmail.com if you want anything changed.